### PR TITLE
Fix prerelease option

### DIFF
--- a/news/5175.bugfix
+++ b/news/5175.bugfix
@@ -1,0 +1,1 @@
+Fix `PackageFinder.find_all_candidates` to enforce `allow_all_prereleases` option 

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -463,6 +463,44 @@ def test_finder_installs_pre_releases(data):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
+def test_finder_does_not_candidate_pre_releases(data):
+    """
+    Test PackageFinder finds pre-releases if asked to.
+    """
+
+    req = install_req_from_line("bar", None)
+
+    # using a local index (that has pre & dev releases)
+    finder = PackageFinder(
+        [], [data.index_url("pre")],
+        allow_all_prereleases=False,
+        session=PipSession(),
+    )
+    for link in finder.find_all_candidates("bar"):
+        assert not link.version.is_prerelease
+
+    # using find-links
+    links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
+    finder = PackageFinder(
+        links, [],
+        allow_all_prereleases=True,
+        session=PipSession(),
+    )
+
+    with patch.object(finder, "_get_pages", lambda x, y: []):
+        for link in finder.find_all_candidates("bar"):
+            assert not link.version.is_prerelease
+
+    links.reverse()
+    finder = PackageFinder(
+        links, [],
+        allow_all_prereleases=True,
+        session=PipSession(),
+    )
+
+    with patch.object(finder, "_get_pages", lambda x, y: []):
+        for link in finder.find_all_candidates("bar"):
+            assert not link.version.is_prerelease
 
 def test_finder_installs_dev_releases(data):
     """

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -476,8 +476,8 @@ def test_finder_does_not_candidate_pre_releases(data):
         allow_all_prereleases=False,
         session=PipSession(),
     )
-    for link in finder.find_all_candidates("bar"):
-        assert not link.version.is_prerelease
+    for candidate in finder.find_all_candidates("bar"):
+        assert not candidate.version.is_prerelease
 
     # using find-links
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
@@ -488,8 +488,8 @@ def test_finder_does_not_candidate_pre_releases(data):
     )
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
-        for link in finder.find_all_candidates("bar"):
-            assert not link.version.is_prerelease
+        for candidate in finder.find_all_candidates("bar"):
+            assert not candidate.version.is_prerelease
 
     links.reverse()
     finder = PackageFinder(
@@ -499,8 +499,8 @@ def test_finder_does_not_candidate_pre_releases(data):
     )
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
-        for link in finder.find_all_candidates("bar"):
-            assert not link.version.is_prerelease
+        for candidate in finder.find_all_candidates("bar"):
+            assert not candidate.version.is_prerelease
 
 def test_finder_installs_dev_releases(data):
     """


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
